### PR TITLE
Pin AWS provider version >= 3.42.0

### DIFF
--- a/new-metric-stream.tf
+++ b/new-metric-stream.tf
@@ -1,4 +1,13 @@
 
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = ">= 3.42.0"
+    }
+  }
+}
+
 provider "aws" {
   region = var.aws_region
 }


### PR DESCRIPTION
This is the first release to support `aws_cloudwatch_metric_stream`.