### PR TITLE
[LS-25786] Added expiration setting for s3 bucket

### DIFF
--- a/example.tfvars
+++ b/example.tfvars
@@ -25,6 +25,9 @@ namespace_list = [
 ## Custom settings ##
 ##################### 
 
+## Expiration
+# expiration_days = 90
+
 ## Endpoints
 ## ---------
 

--- a/new-metric-stream.tf
+++ b/new-metric-stream.tf
@@ -161,6 +161,14 @@ data "aws_iam_policy_document" "lightstep_firehose_s3_backup" {
 resource "aws_s3_bucket" "lightstep_firehose_backup" {
   bucket = "${var.firehose_name}-firehose-s3-backup-${data.aws_caller_identity.current.account_id}"
   force_destroy = true
+  lifecycle_rule {
+    id      = "expiration"
+    enabled = true
+
+    expiration {
+        days = var.expiration_days
+    }
+  }
 }
 
 ## no public access allowed to the backup bucket

--- a/variables.tf
+++ b/variables.tf
@@ -59,3 +59,9 @@ variable "aws_region" {
   type        = string
   default     = "us-west-2"
 }
+
+variable "expiration_days" {
+  description = "How many days to keep failed requests in S3"
+  type = number
+  default = 90
+}


### PR DESCRIPTION
This PR adds an expiration in days for all objects in the backup s3 bucket. The default for this bucket is 90 days. I ran the tf changes, and confirmed that a 90 day expiration for all objects in my bucket was added in AWS.