### PR TITLE
incorporating role for resource enrichment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+# only allow the example tfvars.  Nothing else that users may create while testing or applying.
+*.tfvars
+!example.tfvars

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ var.lightstep_access_token
 
 
 # The above is the minimal install with default values.
-# For custom install, edit example.tfvars.  Then run:
-% terraform apply -var-file="example.tfvars"
+# For custom install, copy example.tfvars (eg: `cp example.tfvars my-vars.tfvars`), edit the new file, then run:
+% terraform apply -var-file="my-vars.tfvars"
 ```
 
 It may take up to 15 minutes for data to appear in your Lightstep project depending on your chosen values for `buffer_interval` (default: 5 min) and `buffer_size` (default: 5 Mib).

--- a/base.tf
+++ b/base.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = ">= 3.42.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_caller_identity" "current" {}

--- a/example.tfvars
+++ b/example.tfvars
@@ -15,6 +15,9 @@ namespace_list = [
   # ...
 ]
 
+## OPTIONAL - A randomly generated alphabetical string used to autheticate between Lightstep and your AWS account. Default: <none>
+# external_id = ""
+
 ## OPTIONAL - select your AWS region
 ## The AWS region associated with your CloudWatch metric stream and Kinesis firehose,
 ## if not the default (us-west-2).

--- a/new-metric-stream.tf
+++ b/new-metric-stream.tf
@@ -1,18 +1,5 @@
 
-terraform {
-  required_providers {
-    aws = {
-      source = "hashicorp/aws"
-      version = ">= 3.42.0"
-    }
-  }
-}
 
-provider "aws" {
-  region = var.aws_region
-}
-
-data "aws_caller_identity" "current" {}
 
 
 resource "aws_cloudwatch_metric_stream" "main" {
@@ -179,4 +166,7 @@ resource "aws_s3_bucket_public_access_block" "backup_bucket_no_public_access" {
   restrict_public_buckets = true
   ignore_public_acls = true
 }
+
+
+## roles required for resource enrichment service
 

--- a/resource-enrichment.tf
+++ b/resource-enrichment.tf
@@ -1,0 +1,72 @@
+# Overview:
+#
+# This Terraform snippet creates the AWS role LightstepAWSIntegrationRole and
+# configures the role so that it can be assumed by Lightstep.
+# It creates and attaches the policy LightstepAWSIntegrationPolicy, which allows
+# reading of EC2 instance data and CloudWatch metrics.
+#
+# Use:
+#
+# This snippet is intended to be sent to one of Lightstep's customers. They
+# will replace [add id here] with their external id of choice and then run
+# `terraform apply`. The customer will then send their TAM:
+#   1. The ARN of the newly created LightstepAWSIntegrationRole role
+#   2. The external ID chosen, if any
+#
+# Requirements:
+#
+#  - AWS CLI tool is installed
+#  - AWS credentials are configured locally
+
+
+resource "aws_iam_role" "lightstep_role" {
+  name        = "LightstepAWSIntegrationRole"
+  description = "Role that Lightstep will assume as part of CloudWatch integration"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::297975325230:root"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${var.external_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "lightstep_policy" {
+  name        = "LightstepAWSIntegrationPolicy"
+  description = "Policy associated with LightstepAWSIntegrationRole"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "VisualEditor0",
+      "Effect": "Allow",
+      "Action": [
+        "tag:GetResources",
+        "ec2:DescribeRegions"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "lightstep_attach" {
+  role       = aws_iam_role.lightstep_role.name
+  policy_arn = aws_iam_policy.lightstep_policy.arn
+}

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "lightstep_access_token" {
   sensitive = true
 }
 
+variable "external_id" {
+  description = "A randomly generated alphabetical string used to autheticate between Lightstep and your AWS account. Default: <empty>"
+  type    = string
+  default = ""
+}
+
 variable "namespace_list" {
   description = "List of namespaces to include in metric stream.  Default: ALL"
   type    = list(string)


### PR DESCRIPTION

This PR adds a step we forgot when doing the terraform to set up a metric stream:  we still need an integration role to assume for doing resource enrichment.  This adds in the old snippet used to setup cwingest (see documentation: https://docs.lightstep.com/docs/setup-aws-for-metrics) and tweaks it slightly for resource enrichment only.