### PR TITLE
Ls 25804 allow upgrade from cwingest

### DIFF
--- a/resource-enrichment.tf
+++ b/resource-enrichment.tf
@@ -4,9 +4,14 @@
 # configures the role so that it can be assumed by Lightstep.
 # It creates and attaches the policy LightstepAWSIntegrationPolicy, which allows
 # reading of EC2 instance data and CloudWatch metrics.
+#
+# This file does not need to run if the customer has previously set up Lightstep's AWS integration 
+# prior to the release of the Metric Streams integration. 
+# Please set the `upgrade_to_streams` variable to `true` before applying this terraform.
 
 
 resource "aws_iam_role" "lightstep_role" {
+  count       = var.upgrade_to_streams ? 0 : 1
   name        = "LightstepAWSIntegrationRole"
   description = "Role that Lightstep will assume as part of CloudWatch integration"
 
@@ -32,6 +37,7 @@ EOF
 }
 
 resource "aws_iam_policy" "lightstep_policy" {
+  count       = var.upgrade_to_streams ? 0 : 1
   name        = "LightstepAWSIntegrationPolicy"
   description = "Policy associated with LightstepAWSIntegrationRole"
 
@@ -54,6 +60,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "lightstep_attach" {
-  role       = aws_iam_role.lightstep_role.name
-  policy_arn = aws_iam_policy.lightstep_policy.arn
+  count      = var.upgrade_to_streams ? 0 : 1
+  role       = aws_iam_role.lightstep_role[0].name
+  policy_arn = aws_iam_policy.lightstep_policy[0].arn
 }

--- a/resource-enrichment.tf
+++ b/resource-enrichment.tf
@@ -4,19 +4,6 @@
 # configures the role so that it can be assumed by Lightstep.
 # It creates and attaches the policy LightstepAWSIntegrationPolicy, which allows
 # reading of EC2 instance data and CloudWatch metrics.
-#
-# Use:
-#
-# This snippet is intended to be sent to one of Lightstep's customers. They
-# will replace [add id here] with their external id of choice and then run
-# `terraform apply`. The customer will then send their TAM:
-#   1. The ARN of the newly created LightstepAWSIntegrationRole role
-#   2. The external ID chosen, if any
-#
-# Requirements:
-#
-#  - AWS CLI tool is installed
-#  - AWS credentials are configured locally
 
 
 resource "aws_iam_role" "lightstep_role" {

--- a/variables.tf
+++ b/variables.tf
@@ -19,13 +19,13 @@ variable "namespace_list" {
 variable "ingest_endpoint" {
   description = "URL of Lightstep ingest"
   type = string
-  default = "https://ingest.lightstep.com/cwstream"
+  default = "https://ingest.staging.lightstep.com/cwstream"
 }
 
 variable "ingest_endpoint_name" {
   description = "Name of Lightstep ingest"
   type = string
-  default = "Lightstep ingest"
+  default = "Lightstep staging"
 }
 
 variable "buffer_size" {
@@ -70,4 +70,10 @@ variable "expiration_days" {
   description = "How many days to keep failed requests in S3"
   type = number
   default = 90
+}
+
+variable "upgrade_to_streams" {
+  description = "Set to true if you are upgrading from our previous AWS integration to our Metric Streams integration. Otherwise you may see errors relating to policies already existing."
+  type = bool
+  default = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,13 +19,13 @@ variable "namespace_list" {
 variable "ingest_endpoint" {
   description = "URL of Lightstep ingest"
   type = string
-  default = "https://ingest.staging.lightstep.com/cwstream"
+  default = "https://ingest.lightstep.com/cwstream"
 }
 
 variable "ingest_endpoint_name" {
   description = "Name of Lightstep ingest"
   type = string
-  default = "Lightstep staging"
+  default = "Lightstep ingest"
 }
 
 variable "buffer_size" {


### PR DESCRIPTION
As described in the [internal upgrade document](https://lightstep.atlassian.net/wiki/spaces/EPD/pages/2552430595/CWINGEST+-+CWSTREAM+RESOURCEENRICHMENT), there can be issues upgrading from cwingest to cwstream/resourceenrichment due to naming conflicts and desynchronization of the external id. 

This PR adds a variable `upgrade_to_streams`, which will prevent touching the old cwingest resources when upgrading.