### PR TITLE
fixing bug where empty external id could cause authentication errors

### DIFF
--- a/example.tfvars
+++ b/example.tfvars
@@ -15,8 +15,8 @@ namespace_list = [
   # ...
 ]
 
-## OPTIONAL - A randomly generated alphabetical string used to autheticate between Lightstep and your AWS account. Default: <none>
-external_id = "foo"
+## OPTIONAL - A randomly generated string used to autheticate between Lightstep and your AWS account. Default: <none>
+# external_id = "RandomString"
 
 ## OPTIONAL - select your AWS region
 ## The AWS region associated with your CloudWatch metric stream and Kinesis firehose,

--- a/example.tfvars
+++ b/example.tfvars
@@ -16,7 +16,7 @@ namespace_list = [
 ]
 
 ## OPTIONAL - A randomly generated alphabetical string used to autheticate between Lightstep and your AWS account. Default: <none>
-# external_id = ""
+external_id = "foo"
 
 ## OPTIONAL - select your AWS region
 ## The AWS region associated with your CloudWatch metric stream and Kinesis firehose,

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,6 @@ variable "lightstep_access_token" {
 variable "external_id" {
   description = "A randomly generated alphabetical string used to autheticate between Lightstep and your AWS account. Default: <empty>"
   type    = string
-  default = ""
 }
 
 variable "namespace_list" {

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "lightstep_access_token" {
 }
 
 variable "external_id" {
-  description = "A randomly generated alphabetical string used to autheticate between Lightstep and your AWS account. Default: <empty>"
+  description = "A randomly generated string used to autheticate between Lightstep and your AWS account. Default: <empty>"
   type    = string
 }
 


### PR DESCRIPTION
What does this PR do?
---------------------
Sets up conditional conditions for our assume role policy depending on whether or not the user provides an `external_id`

Why are you doing it?
---------------------
When the external id variable is unset we aren't actually able to assume the integration role properly.  The terraform sets up a condition which requires an empty value for `sts:external_id`.  However, you can't supply an empty value when connecting since validation rules require a non-zero length. We have to create the condition only when an `external_id` is supplied and leave it off if empty.

What are you asking the reviewer to do?
---------------------
The usual, along with any suggestions for better ways to do a conditional in terraform.

***
R/CC: @lightstep/team-data-onboarding 

Please see [go/good-pr](http://go/good-pr) for more details and tips on writing better PR descriptions.
