### PR TITLE
external_id is no longer an input variable.  it is generated by the script and outputted

### DIFF
--- a/example.tfvars
+++ b/example.tfvars
@@ -10,13 +10,10 @@ lightstep_access_token           = "<lightstep-access-token-here>"
 ## OPTIONAL - restrict the metric stream to a list of namespaces
 ## Leaving this empty will include ALL namespaces
 namespace_list = [
-  # "AWS/ApiGateway",
-  # "AWS/Lambda",
+  "AWS/ApiGateway",
+  "AWS/Lambda",
   # ...
 ]
-
-## OPTIONAL - A randomly generated string used to autheticate between Lightstep and your AWS account. Default: <none>
-# external_id = "RandomString"
 
 ## OPTIONAL - select your AWS region
 ## The AWS region associated with your CloudWatch metric stream and Kinesis firehose,

--- a/example.tfvars
+++ b/example.tfvars
@@ -10,8 +10,8 @@ lightstep_access_token           = "<lightstep-access-token-here>"
 ## OPTIONAL - restrict the metric stream to a list of namespaces
 ## Leaving this empty will include ALL namespaces
 namespace_list = [
-  "AWS/ApiGateway",
-  "AWS/Lambda",
+  #"AWS/ApiGateway",
+  #"AWS/Lambda",
   # ...
 ]
 

--- a/example.tfvars
+++ b/example.tfvars
@@ -10,8 +10,8 @@ lightstep_access_token           = "<lightstep-access-token-here>"
 ## OPTIONAL - restrict the metric stream to a list of namespaces
 ## Leaving this empty will include ALL namespaces
 namespace_list = [
-  #"AWS/ApiGateway",
-  #"AWS/Lambda",
+  # "AWS/ApiGateway",
+  # "AWS/Lambda",
   # ...
 ]
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,7 @@
+output "role_arn" {
+  value = aws_iam_role.lightstep_role[0].arn
+}
+
+output "external_id" {
+  value = random_string.external_id.result
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,9 @@
-output "role_arn" {
+output "integration_role_arn" {
   value = aws_iam_role.lightstep_role[0].arn
+  description = "The ARN of the role Lightstep will use to retrieve resource metadata. It must be entered into the Lightstep UI to complete the integration."
 }
 
 output "external_id" {
   value = random_string.external_id.result
+  description = "A unique string which identifies Ligtstep to your AWS account when we pull resource metadata. It must be entered into the Lightstep UI to complete the integration. For details, see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html"
 }

--- a/resource-enrichment.tf
+++ b/resource-enrichment.tf
@@ -16,8 +16,6 @@ resource "random_string" "external_id" {
   override_special = "_=,.@:/-"
 }
 
-
-# When an external id is provided, we configure a condition on role assumption
 data "aws_iam_policy_document" "lightstep_assume_role_policy" {
   statement {
     actions = [

--- a/variables.tf
+++ b/variables.tf
@@ -4,11 +4,6 @@ variable "lightstep_access_token" {
   sensitive = true
 }
 
-variable "external_id" {
-  description = "A randomly generated string used to autheticate between Lightstep and your AWS account. Default: <empty>"
-  type    = string
-}
-
 variable "namespace_list" {
   description = "List of namespaces to include in metric stream.  Default: ALL"
   type    = list(string)


### PR DESCRIPTION
This PR removes `external_id` as an input variable.
It is generated by the terraform and displayed as an output.

The user should then follow instructions to copy this value into their integration via the Lightstep UI.

See https://lightstep.atlassian.net/browse/LS-26944 for details.