### PR TITLE
Convert to Terraform Module, Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: Automatic CI for TFE Modules
+
+on:
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  terraform_format:
+
+    name: Run terraform fmt
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        persist-credentials: false
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 1.0.11
+
+    - name: Format all .tf files recursively
+      run: |
+        terraform fmt -check -diff -recursive ${{ github.workspace }}
+  terraform_lint:
+
+    name: Run terraform-lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        persist-credentials: false
+
+    - name: Setup Terraform Lint
+      uses: terraform-linters/setup-tflint@v1
+      with:
+        tflint_version: v0.26.0
+
+    - name: Lint root module
+      run: |
+        tflint --config ${{ github.workspace }}/.tflint.hcl ${{ github.workspace }}
+    - name: Lint modules directory in a loop
+      run: |
+        for m in $(ls -1d modules/*/)
+        do
+          tflint \
+            --config ${{ github.workspace }}/.tflint.hcl \
+            ${{ github.workspace }}/${m}
+        done

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev:  v0.1.17
+    hooks:
+      - id: terraform-fmt
+      - id: tflint
+        args:
+          - "--module"
+          - "--config=.tflint.hcl"

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,53 @@
+config {
+  module = false
+}
+
+plugin "aws" {
+    enabled = true
+    version = "0.5.0"
+    source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+rule "terraform_deprecated_index" {
+  enabled = true
+}
+
+rule "terraform_unused_declarations" {
+  enabled = true
+}
+
+rule "terraform_comment_syntax" {
+  enabled = true
+}
+
+rule "terraform_documented_outputs" {
+  enabled = true
+}
+
+rule "terraform_documented_variables" {
+  enabled = true
+}
+
+rule "terraform_typed_variables" {
+  enabled = true
+}
+
+rule "terraform_naming_convention" {
+  enabled = true
+}
+
+rule "terraform_required_version" {
+  enabled = true
+}
+
+rule "terraform_required_providers" {
+  enabled = true
+}
+
+rule "terraform_unused_required_providers" {
+  enabled = true
+}
+
+rule "terraform_standard_module_structure" {
+  enabled = true
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # aws-cloudwatch-metric-stream-terraform
 
+Terraform module which creates AWS Cloudwatch Metric Streams to forward data to [Lightstep](https://lioghtstep.com).
 
-### Prerequisites
-1. [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+## Prerequisites
+1. [Terraform v1.0+](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 1. A Lightstep project [access token](https://docs.lightstep.com/docs/create-and-manage-access-tokens)
 1. AWS Access Key/Secret with IAM permissions to create the following resources:
     * aws_cloudwatch_metric_stream 
@@ -11,30 +12,38 @@
     * aws_kinesis_firehose_delivery_stream
     * aws_s3_bucket
     * aws_s3_bucket_public_access_block
-### Installation
 
-```BASH
-% git clone git@github.com:lightstep/aws-cloudwatch-metric-stream-terraform.git
-% cd aws-cloudwatch-metric-stream-terraform
+## Usage
 
-% export AWS_ACCESS_KEY_ID=<access-key-id>
-% export AWS_SECRET_ACCESS_KEY=<secret-access-key>
-% terraform init
-# Enter your Lightstep project access token when prompted
-% terraform apply
-var.lightstep_access_token
-  Lightstep project access token
+### Default
 
-  Enter a value: 
+Add the following module to an existing terraform file. For a full example, see the [`examples/`](https://github.com/lightstep/aws-cloudwatch-metric-stream-terraform/tree/main/examples) directory.
 
-
-
-# The above is the minimal install with default values.
-# For custom install, copy example.tfvars (eg: `cp example.tfvars my-vars.tfvars`), edit the new file, then run:
-% terraform apply -var-file="my-vars.tfvars"
+```hcl
+module "lightstep_cloudwatch_metric_streams" {
+  source  = "git::git@github.com:lightstep/aws-cloudwatch-metric-stream-terraform.git?ref=main"
+  lightstep_access_token = var.lightstep_access_token
+  # For additional configuration options, see example.tfvars
+}
 ```
+
+Run `terraform init` to install the module and `terraform apply` to apply changes and create AWS CloudWatch Metrics streams to send data to Lightstep.
 
 It may take up to 15 minutes for data to appear in your Lightstep project depending on your chosen values for `buffer_interval` (default: 5 min) and `buffer_size` (default: 5 Mib).
 
 ### Options
 All options are documented in `variables.tf` and `example.tfvars`
+
+### Development
+
+This repository uses `pre-commit` to automatically format and lint code before commits.
+
+To configure this git repository:
+
+```
+    # install pre-commit (Mac OS X)
+    $ brew install pre-commit
+
+    # install hooks in this repository
+    $ pre-commit install
+```

--- a/example.tfvars
+++ b/example.tfvars
@@ -4,7 +4,7 @@
 
 ## REQUIRED - your Lightstep project access token
 ## See https://docs.lightstep.com/docs/create-and-manage-access-tokens
-lightstep_access_token           = "<lightstep-access-token-here>"
+lightstep_access_token = "<lightstep-access-token-here>"
 
 
 ## OPTIONAL - restrict the metric stream to a list of namespaces

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,15 @@
+# Example for aws-cloudwatch-metric-stream-terraform
+
+This is an example of using the Terraform module to create AWS CloudWatch Metric Streams to send data to Lightstep.
+
+To run this example:
+
+```
+    $ terraform init
+
+    # Preview changes
+    $ terraform plan
+
+    # Apply changes
+    $ terraform apply
+```

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.73.0"
+    }
+  }
+  required_version = ">= v1.0.11"
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "lightstep_cloudwatch_metric_streams" {
+  # We recommend referencing a specific tag/ref while using the module
+  source = "git::git@github.com:lightstep/aws-cloudwatch-metric-stream-terraform.git?ref=0.0.1"
+
+  lightstep_access_token = var.lightstep_access_token
+
+  # Only send metrics from EC2
+  # For additional options, see example.tfvars
+  namespace_list = [
+    "AWS/EC2",
+  ]
+}

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  description = "The AWS region associated with your CloudWatch metric stream and Kinesis firehose"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "lightstep_access_token" {
+  description = "Lightstep project access token (note: this is *not* an API Key)"
+  type        = string
+  sensitive   = true
+}

--- a/main.tf
+++ b/main.tf
@@ -1,14 +1,15 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">= 3.42.0"
     }
-  }
-}
 
-provider "aws" {
-  region = var.aws_region
+    random = {
+      version = ">= 3.1.0"
+    }
+  }
+  required_version = ">= v1.0.11"
 }
 
 data "aws_caller_identity" "current" {}

--- a/new-metric-stream.tf
+++ b/new-metric-stream.tf
@@ -142,17 +142,22 @@ data "aws_iam_policy_document" "lightstep_firehose_s3_backup" {
 }
 
 ## Kinesis Firehose - S3 error/backup bucket
-resource "aws_s3_bucket" "lightstep_firehose_backup" {
-  bucket        = "${var.firehose_name}-firehose-s3-backup-${data.aws_caller_identity.current.account_id}"
-  force_destroy = true
-  lifecycle_rule {
-    id      = "expiration"
-    enabled = true
+resource "aws_s3_bucket_lifecycle_configuration" "lightstep_firehose_backup_bucket_config" {
+  bucket = aws_s3_bucket.lightstep_firehose_backup.bucket
+  rule {
+    id = "expiration"
 
     expiration {
       days = var.expiration_days
     }
+    status = "Enabled"
   }
+}
+
+resource "aws_s3_bucket" "lightstep_firehose_backup" {
+  bucket        = "${var.firehose_name}-firehose-s3-backup-${data.aws_caller_identity.current.account_id}"
+  force_destroy = true
+
   tags = var.tags
 }
 

--- a/new-metric-stream.tf
+++ b/new-metric-stream.tf
@@ -12,6 +12,7 @@ resource "aws_cloudwatch_metric_stream" "main" {
       namespace = item.value
     }
   }
+  tags = var.tags
 }
 
 
@@ -92,7 +93,7 @@ resource "aws_kinesis_firehose_delivery_stream" "lightstep" {
   server_side_encryption {
     enabled = false
   }
-
+  tags = var.tags
 }
 
 
@@ -152,6 +153,7 @@ resource "aws_s3_bucket" "lightstep_firehose_backup" {
       days = var.expiration_days
     }
   }
+  tags = var.tags
 }
 
 ## no public access allowed to the backup bucket

--- a/new-metric-stream.tf
+++ b/new-metric-stream.tf
@@ -1,7 +1,3 @@
-
-
-
-
 resource "aws_cloudwatch_metric_stream" "main" {
   name          = var.metric_stream_name
   role_arn      = aws_iam_role.lightstep_metric_stream.arn
@@ -96,7 +92,7 @@ resource "aws_kinesis_firehose_delivery_stream" "lightstep" {
   server_side_encryption {
     enabled = false
   }
-  
+
 }
 
 
@@ -146,25 +142,25 @@ data "aws_iam_policy_document" "lightstep_firehose_s3_backup" {
 
 ## Kinesis Firehose - S3 error/backup bucket
 resource "aws_s3_bucket" "lightstep_firehose_backup" {
-  bucket = "${var.firehose_name}-firehose-s3-backup-${data.aws_caller_identity.current.account_id}"
+  bucket        = "${var.firehose_name}-firehose-s3-backup-${data.aws_caller_identity.current.account_id}"
   force_destroy = true
   lifecycle_rule {
     id      = "expiration"
     enabled = true
 
     expiration {
-        days = var.expiration_days
+      days = var.expiration_days
     }
   }
 }
 
 ## no public access allowed to the backup bucket
 resource "aws_s3_bucket_public_access_block" "backup_bucket_no_public_access" {
-  bucket = "${aws_s3_bucket.lightstep_firehose_backup.id}"
-  block_public_acls = true
-  block_public_policy = true
+  bucket                  = aws_s3_bucket.lightstep_firehose_backup.id
+  block_public_acls       = true
+  block_public_policy     = true
   restrict_public_buckets = true
-  ignore_public_acls = true
+  ignore_public_acls      = true
 }
 
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "integration_role_arn" {
-  value = aws_iam_role.lightstep_role[0].arn
+  value       = aws_iam_role.lightstep_role[0].arn
   description = "The ARN of the role Lightstep will use to retrieve resource metadata. It must be entered into the Lightstep UI to complete the integration."
 }
 
 output "external_id" {
-  value = random_string.external_id.result
+  value       = random_string.external_id.result
   description = "A unique string which identifies Ligtstep to your AWS account when we pull resource metadata. It must be entered into the Lightstep UI to complete the integration. For details, see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html"
 }

--- a/resource-enrichment.tf
+++ b/resource-enrichment.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "lightstep_assume_role_policy" {
     actions = [
       "sts:AssumeRole",
     ]
-    
+
     principals {
       type        = "AWS"
       identifiers = ["arn:aws:iam::297975325230:root"]

--- a/resource-enrichment.tf
+++ b/resource-enrichment.tf
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "lightstep_assume_role_policy" {
 
 resource "aws_iam_role" "lightstep_role" {
   count       = var.upgrade_to_streams ? 0 : 1
-  name        = "LightstepAWSIntegrationRole"
+  name        = var.integration_role_name
   description = "Role that Lightstep will assume as part of CloudWatch integration"
 
   assume_role_policy = data.aws_iam_policy_document.lightstep_assume_role_policy.json
@@ -48,7 +48,7 @@ resource "aws_iam_role" "lightstep_role" {
 
 resource "aws_iam_policy" "lightstep_policy" {
   count       = var.upgrade_to_streams ? 0 : 1
-  name        = "LightstepAWSIntegrationPolicy"
+  name        = var.integration_policy_name
   description = "Policy associated with LightstepAWSIntegrationRole"
 
   policy = <<EOF

--- a/variables.tf
+++ b/variables.tf
@@ -1,33 +1,33 @@
 variable "lightstep_access_token" {
   description = "Lightstep project access token"
-  type      = string
-  sensitive = true
+  type        = string
+  sensitive   = true
 }
 
 variable "namespace_list" {
   description = "List of namespaces to include in metric stream.  Default: ALL"
-  type    = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 
 variable "ingest_endpoint" {
   description = "URL of Lightstep ingest"
-  type = string
-  default = "https://ingest.lightstep.com/cwstream"
+  type        = string
+  default     = "https://ingest.lightstep.com/cwstream"
 }
 
 variable "ingest_endpoint_name" {
   description = "Name of Lightstep ingest"
-  type = string
-  default = "Lightstep ingest"
+  type        = string
+  default     = "Lightstep ingest"
 }
 
 variable "buffer_size" {
   description = "Size of metric data (MiB) to accumulate before flushing to Lighstep ingest."
-  type      = number
-  default   = 5
+  type        = number
+  default     = 5
 
-   validation {
+  validation {
     condition     = var.buffer_size >= 1 && var.buffer_size <= 128
     error_message = "Buffer size must be between 1 and 128 MB."
   }
@@ -35,8 +35,8 @@ variable "buffer_size" {
 
 variable "buffer_interval" {
   description = "Time to wait (seconds) before flushing to Lighstep ingest."
-  type      = number
-  default   = 300
+  type        = number
+  default     = 300
 
   validation {
     condition     = var.buffer_interval >= 60 && var.buffer_interval <= 900
@@ -45,29 +45,25 @@ variable "buffer_interval" {
 }
 
 variable "metric_stream_name" {
-  type      = string
-  default   = "lightstep"
+  type        = string
+  default     = "lightstep"
+  description = "Name of the metric stream to be created"
 }
 
 variable "firehose_name" {
-  type      = string
-  default   = "lightstep"
-}
-
-variable "aws_region" {
-  description = "The AWS region associated with your CloudWatch metric stream and Kinesis firehose"
   type        = string
-  default     = "us-west-2"
+  default     = "lightstep"
+  description = "Name of the Firehose to be created"
 }
 
 variable "expiration_days" {
   description = "How many days to keep failed requests in S3"
-  type = number
-  default = 90
+  type        = number
+  default     = 90
 }
 
 variable "upgrade_to_streams" {
   description = "Set to true if you are upgrading from our previous AWS integration to our Metric Streams integration. Otherwise you may see errors relating to policies already existing."
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -67,3 +67,16 @@ variable "upgrade_to_streams" {
   type        = bool
   default     = false
 }
+
+variable "integration_policy_name" {
+  description = "Name of the Lightstep IAM policy for enrichement."
+  type        = string
+  default     = "LightstepAWSIntegrationPolicy"
+}
+
+variable "integration_role_name" {
+  description = "Name of the Lightstep IAM role for enrichement."
+  type        = string
+  default     = "LightstepAWSIntegrationRole"
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -80,3 +80,8 @@ variable "integration_role_name" {
   default     = "LightstepAWSIntegrationRole"
 }
 
+variable "tags" {
+  description = "A map of tags to assign to resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Few small changes + new automations to make this work well with the new [Lightstep Terraform Provider](https://github.com/lightstep/terraform-provider-lightstep).

* Makes the git repository usable as a versioned [Terraform module](https://www.terraform.io/language/modules/develop).
* Adds linting and formatting rules to be consistent with other Terraform modules/repos + GH Action that automatically checks that + a pre-commit hook that does that automatically during development.
* New docs that follow terraform module conventions (`examples/` dir) that show how to use it.

Note that there are some small formatting changes, but no resources/etc have been modified.